### PR TITLE
<FEAT>: "게시물 로드 및 저장 백엔드 구현"

### DIFF
--- a/src/main/java/com/surenusi/springbootposts/dto/posts/PostsMainResponseDto.java
+++ b/src/main/java/com/surenusi/springbootposts/dto/posts/PostsMainResponseDto.java
@@ -1,0 +1,34 @@
+package com.surenusi.springbootposts.dto.posts;
+
+import com.surenusi.springbootposts.domain.Posts;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+@Getter
+public class PostsMainResponseDto {
+
+    private Long id;
+    private String title;
+    private String content;
+    private String author;
+    private String modifiedDate;
+
+    public PostsMainResponseDto(Posts posts) {
+        id = posts.getId();
+        title = posts.getTitle();
+        content = posts.getContent();
+        author = posts.getAuthor();
+        modifiedDate = toStringDateTime(posts.getModifiedDate());
+    }
+
+    //LocalDateTime타입 -> String타입 형변환
+    public String toStringDateTime(LocalDateTime localDateTime) {
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        return Optional.ofNullable(localDateTime)
+                .map(dateTimeFormatter::format)
+                .orElse("");
+    }
+}

--- a/src/main/java/com/surenusi/springbootposts/dto/posts/PostsSaveRequestDto.java
+++ b/src/main/java/com/surenusi/springbootposts/dto/posts/PostsSaveRequestDto.java
@@ -1,13 +1,10 @@
 package com.surenusi.springbootposts.dto.posts;
 
 import com.surenusi.springbootposts.domain.Posts;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
-@Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostsSaveRequestDto {
 
     private String title;

--- a/src/main/java/com/surenusi/springbootposts/dto/user/UsersSaveRequestDto.java
+++ b/src/main/java/com/surenusi/springbootposts/dto/user/UsersSaveRequestDto.java
@@ -1,13 +1,10 @@
 package com.surenusi.springbootposts.dto.user;
 
 import com.surenusi.springbootposts.domain.Users;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
-@Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UsersSaveRequestDto {
 
     private String login;

--- a/src/main/java/com/surenusi/springbootposts/repository/PostsRepository.java
+++ b/src/main/java/com/surenusi/springbootposts/repository/PostsRepository.java
@@ -3,5 +3,9 @@ package com.surenusi.springbootposts.repository;
 import com.surenusi.springbootposts.domain.Posts;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.stream.Stream;
+
 public interface PostsRepository extends JpaRepository<Posts, Long> {
+
+    Stream<Posts> findByOrderByIdDesc();
 }

--- a/src/main/java/com/surenusi/springbootposts/service/PostsService.java
+++ b/src/main/java/com/surenusi/springbootposts/service/PostsService.java
@@ -1,0 +1,29 @@
+package com.surenusi.springbootposts.service;
+
+import com.surenusi.springbootposts.dto.posts.PostsMainResponseDto;
+import com.surenusi.springbootposts.dto.posts.PostsSaveRequestDto;
+import com.surenusi.springbootposts.repository.PostsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PostsService {
+
+    private final PostsRepository postsRepository;
+
+    @Transactional
+    public Long save(PostsSaveRequestDto dto) {
+        return postsRepository.save(dto.toEntity()).getId();
+    }
+
+    public List<PostsMainResponseDto> findAllDesc() {
+        return postsRepository.findByOrderByIdDesc()
+                .map(PostsMainResponseDto::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/surenusi/springbootposts/web/WebController.java
+++ b/src/main/java/com/surenusi/springbootposts/web/WebController.java
@@ -1,0 +1,20 @@
+package com.surenusi.springbootposts.web;
+
+import com.surenusi.springbootposts.service.PostsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+@RequiredArgsConstructor
+public class WebController {
+
+    private final PostsService postsService;
+
+    @GetMapping("/")
+    public String main(Model model) {
+        model.addAttribute("posts", postsService.findAllDesc());
+        return "main";
+    }
+}

--- a/src/main/java/com/surenusi/springbootposts/web/WebRestController.java
+++ b/src/main/java/com/surenusi/springbootposts/web/WebRestController.java
@@ -1,40 +1,20 @@
 package com.surenusi.springbootposts.web;
 
-import com.surenusi.springbootposts.domain.Posts;
 import com.surenusi.springbootposts.dto.posts.PostsSaveRequestDto;
-import com.surenusi.springbootposts.dto.user.UsersSaveRequestDto;
 import com.surenusi.springbootposts.repository.PostsRepository;
-import com.surenusi.springbootposts.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Map;
-
-/**
- * API 테스트를 위해 작성되었음
- */
 @RestController
 @RequiredArgsConstructor
 public class WebRestController {
 
     private final PostsRepository postsRepository;
-    private final UsersRepository usersRepository;
-
-    @GetMapping("/hello")
-    public String hello() {
-        return "HelloWorld";
-    }
 
     @PostMapping("/posts")
     public void savePosts(@RequestBody PostsSaveRequestDto dto) {
         postsRepository.save(dto.toEntity());
-    }
-
-    @PostMapping("/users")
-    public void saveUser(@RequestBody UsersSaveRequestDto dto) {
-        usersRepository.save(dto.toEntity());
     }
 }


### PR DESCRIPTION
main페이지 Response에 필요한 PostsMainResponseDto 클래스 추가
PostsService클래스에 저장 및 로드를 위한 메소드 추가(save(), findByOrderByIdDesc())
페이지 리다이렉트를 위한 WebController 클래스 추가
이외에 테스트를 위해 작성되었던 부분 수정(PostsSaveRequestDto, UsersSaveRequestDto, WebRestController)